### PR TITLE
add : overrides path-scurry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "chokidar": "^3.5.3",
         "commander": "^10.0.1",
         "ejs": "^3.1.9",
-        "glob": "^10.2.2",
+        "glob": "^10.2.6",
         "recursive-copy": "^2.0.14",
         "source-map-loader": "^4.0.1",
         "ts-loader": "^9.4.2",
@@ -27,7 +27,6 @@
       },
       "devDependencies": {
         "@types/ejs": "^3.1.2",
-        "@types/node": "^20.1.0",
         "moment": "^2.29.4",
         "prettier": "^2.8.8",
         "pretty-quick": "^3.1.3",
@@ -1692,9 +1691,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.1.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.1.0.tgz",
-      "integrity": "sha512-O+z53uwx64xY7D6roOi4+jApDGFg0qn6WHcxe5QeqjMaTezBO/mxdfFXIVAVVyNWKx84OmPB3L8kbVYOTeN34A=="
+      "version": "20.2.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.2.5.tgz",
+      "integrity": "sha512-JJulVEQXmiY9Px5axXHeYGLSjhkZEnD+MDPDGbCbIAbMslkKwmygtZFy1X6s/075Yo94sf8GuSlFfPzysQrWZQ=="
     },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.11.5",
@@ -3323,12 +3322,12 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "node_modules/path-scurry": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.7.0.tgz",
-      "integrity": "sha512-UkZUeDjczjYRE495+9thsgcVgsaCPkaw80slmfVFgllxY+IO8ubTsOpFVjDPROBqJdHfVPUFRHPBV/WciOVfWg==",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.9.2.tgz",
+      "integrity": "sha512-qSDLy2aGFPm8i4rsbHd4MNyTcrzHFsLQykrtbuGRknZZCBBVXSv2tSCDN2Cg6Rt/GFRw8GoW9y9Ecw5rIPG1sg==",
       "dependencies": {
-        "lru-cache": "^9.0.0",
-        "minipass": "^5.0.0"
+        "lru-cache": "^9.1.1",
+        "minipass": "^5.0.0 || ^6.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -5620,9 +5619,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "20.1.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.1.0.tgz",
-      "integrity": "sha512-O+z53uwx64xY7D6roOi4+jApDGFg0qn6WHcxe5QeqjMaTezBO/mxdfFXIVAVVyNWKx84OmPB3L8kbVYOTeN34A=="
+      "version": "20.2.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.2.5.tgz",
+      "integrity": "sha512-JJulVEQXmiY9Px5axXHeYGLSjhkZEnD+MDPDGbCbIAbMslkKwmygtZFy1X6s/075Yo94sf8GuSlFfPzysQrWZQ=="
     },
     "@webassemblyjs/ast": {
       "version": "1.11.5",
@@ -6280,7 +6279,7 @@
         "jackspeak": "^2.0.3",
         "minimatch": "^9.0.1",
         "minipass": "^5.0.0 || ^6.0.2",
-        "path-scurry": "^1.7.0"
+        "path-scurry": "^1.9.2"
       },
       "dependencies": {
         "minimatch": {
@@ -6831,12 +6830,12 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "path-scurry": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.7.0.tgz",
-      "integrity": "sha512-UkZUeDjczjYRE495+9thsgcVgsaCPkaw80slmfVFgllxY+IO8ubTsOpFVjDPROBqJdHfVPUFRHPBV/WciOVfWg==",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.9.2.tgz",
+      "integrity": "sha512-qSDLy2aGFPm8i4rsbHd4MNyTcrzHFsLQykrtbuGRknZZCBBVXSv2tSCDN2Cg6Rt/GFRw8GoW9y9Ecw5rIPG1sg==",
       "requires": {
-        "lru-cache": "^9.0.0",
-        "minipass": "^5.0.0"
+        "lru-cache": "^9.1.1",
+        "minipass": "^5.0.0 || ^6.0.2"
       },
       "dependencies": {
         "lru-cache": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "chokidar": "^3.5.3",
     "commander": "^10.0.1",
     "ejs": "^3.1.9",
-    "glob": "^10.2.2",
+    "glob": "^10.2.6",
     "recursive-copy": "^2.0.14",
     "source-map-loader": "^4.0.1",
     "ts-loader": "^9.4.2",
@@ -35,11 +35,13 @@
   },
   "devDependencies": {
     "@types/ejs": "^3.1.2",
-    "@types/node": "^20.1.0",
     "moment": "^2.29.4",
     "prettier": "^2.8.8",
     "pretty-quick": "^3.1.3",
     "webpack-glsl-loader": "^1.0.1"
+  },
+  "overrides": {
+    "path-scurry": "^1.9.2"
   },
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
globが依存しているpath-scurryモジュールが1.7.0から更新されていないため、ビルドに失敗する。一時的にoverridesフィールドで対応する。globが対応した後に削除すること。