### PR TITLE
add : extensionAlias

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -48,6 +48,10 @@ const defaultOption = {
   },
   resolve: {
     extensions: [".ts", ".js"],
+    extensionAlias: {
+      ".js": [".ts", ".js"],
+      ".mjs": [".mts", ".mjs"],
+    },
   },
   optimization: {
     splitChunks: {


### PR DESCRIPTION
TypeScript内で拡張子付きimportを行なった場合、モジュール名の解決に失敗した。拡張子のエイリアスを設定することで問題を解決した。