### PR TITLE
Fix: Handle subdirectories in getDemoNameFromPath (#523)

### DIFF
--- a/__test__/indexScript.spec.js
+++ b/__test__/indexScript.spec.js
@@ -21,7 +21,7 @@ const { getDemoNameFromPath } = context;
 describe("getDemoNameFromPath", () => {
   it("should extract the demo name from a valid path", () => {
     const path = "demo/demoTypeScript.html";
-    expect(getDemoNameFromPath(path)).toBe("demoTypeScript");
+    expect(getDemoNameFromPath(path)).toBe("demo%2FdemoTypeScript");
   });
 
   it("should return null for an invalid path", () => {
@@ -41,6 +41,11 @@ describe("getDemoNameFromPath", () => {
 
   it("should handle paths with multiple dots in the filename", () => {
     const path = "demo/my.test.demo.html";
-    expect(getDemoNameFromPath(path)).toBe("my.test.demo");
+    expect(getDemoNameFromPath(path)).toBe("demo%2Fmy.test.demo");
+  });
+
+  it('should extract "sub%2FdemoSub" from "sub/demoSub.html"', () => {
+    const path = "sub/demoSub.html";
+    expect(getDemoNameFromPath(path)).toBe("sub%2FdemoSub");
   });
 });

--- a/template/indexScript.js
+++ b/template/indexScript.js
@@ -1,14 +1,15 @@
 /**
- * デモパスからデモ名を抽出 (例: "demo/demoTypeScript.html" -> "demoTypeScript")
+ * デモパスからデモ名を抽出し、URLエンコードされたデモ名を返します (例: "sub/demoSub.html" -> "sub%2FdemoSub")
  */
 function getDemoNameFromPath(path) {
   if (!path) return null;
 
-  var parts = path.split("/");
-  var fileName = parts[parts.length - 1];
-
-  if (fileName.endsWith(".html")) {
-    return fileName.substring(0, fileName.length - ".html".length);
+  var demoPath = path;
+  if (demoPath.endsWith(".html")) {
+    demoPath = demoPath.substring(0, demoPath.length - ".html".length);
+  } else {
+    return null; // Only process .html files
   }
-  return null;
+
+  return encodeURIComponent(demoPath);
 }


### PR DESCRIPTION
Addresses Issue #523 by modifying the `getDemoNameFromPath` function in `template/indexScript.js`.

__Problem:__ When extracting the demo name for demo files located in subdirectories (e.g., `demoSrc/sub/demoSub.js`), the directory structure was not considered, and only the filename was extracted. This caused URL parameter conflicts when files with the same name existed in different directories.

__Solution:__ The `getDemoNameFromPath` function has been modified to return the entire string of the demo file path after removing the `.html` extension, URL-encoded. This ensures that demo names including subdirectories are uniquely identified.

__Tests:__ A new test case for paths including subdirectories has been added to `__test__/indexScript.spec.js`. The expected values for existing relevant test cases have also been updated to match the new behavior of `getDemoNameFromPath`. All tests have been confirmed to pass.

Related Issue: #523
