### PR TITLE
Update Node.js version matrix to remove 18.x

### DIFF
--- a/.github/workflows/buildJS.yml
+++ b/.github/workflows/buildJS.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [20.x, 22.x]
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
Remove Node.js version 18.x from the workflow configuration to streamline the build process.