### PR TITLE
Integrate Biome for formatting and linting, enhance type safety and code consistency

### DIFF
--- a/.github/workflows/buildJS.yml
+++ b/.github/workflows/buildJS.yml
@@ -20,4 +20,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: "npm"
       - run: npm ci
+      - name: Run Biome
+        run: npx biome ci .
       - run: npm test

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,1 +1,5 @@
+#!/usr/bin/env sh
+set -e
+
+npx biome ci .
 npx vitest --run

--- a/__test__/Bundler.spec.ts
+++ b/__test__/Bundler.spec.ts
@@ -1,12 +1,11 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
 import { getBundlerSet } from "../src/Bundler.js";
 import { initOptions } from "../src/Option.js";
 import { isExistFile } from "./Util.js";
-import { vi, expect, describe, test, afterEach } from "vitest";
 
 describe("Bundler", () => {
   const spyLog = vi.spyOn(console, "log").mockImplementation(() => {});
-  const spyWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
-
+  const _spyWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
   const spyError = vi.spyOn(console, "error").mockImplementation(() => {});
 
   const getDefaultBundlerSet = async () => {

--- a/__test__/Bundler.spec.ts
+++ b/__test__/Bundler.spec.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test, vi } from "vitest";
+import { afterAll, afterEach, describe, expect, test, vi } from "vitest";
 import { getBundlerSet } from "../src/Bundler.js";
 import { initOptions } from "../src/Option.js";
 import { isExistFile } from "./Util.js";
@@ -15,6 +15,12 @@ describe("Bundler", () => {
 
   afterEach(() => {
     vi.clearAllMocks();
+  });
+
+  afterAll(() => {
+    spyLog.mockRestore();
+    _spyWarn.mockRestore();
+    spyError.mockRestore();
   });
 
   test("getBundlerSet", async () => {

--- a/__test__/Clean.spec.ts
+++ b/__test__/Clean.spec.ts
@@ -1,4 +1,4 @@
-import { describe, test, vi } from "vitest";
+import { afterAll, describe, test, vi } from "vitest";
 import { getBundlerSet } from "../src/Bundler.js";
 import { getCleanTask } from "../src/Clean.js";
 import { initOptions } from "../src/Option.js";
@@ -6,6 +6,10 @@ import { isExistFile, isNotExistFile } from "./Util.js";
 
 describe("Clean", () => {
   const _spyLog = vi.spyOn(console, "log").mockImplementation(() => {});
+
+  afterAll(() => {
+    _spyLog.mockRestore();
+  });
 
   test("clean", async () => {
     const option = initOptions({ distDir: "./cleanTest" });

--- a/__test__/Clean.spec.ts
+++ b/__test__/Clean.spec.ts
@@ -1,11 +1,11 @@
-import { getBundlerSet } from "../src/Bundler.js";
-import { initOptions } from "../src/Option.js";
-import { getCleanTask } from "../src/Clean.js";
-import { isExistFile, isNotExistFile } from "./Util.js";
 import { describe, test, vi } from "vitest";
+import { getBundlerSet } from "../src/Bundler.js";
+import { getCleanTask } from "../src/Clean.js";
+import { initOptions } from "../src/Option.js";
+import { isExistFile, isNotExistFile } from "./Util.js";
 
 describe("Clean", () => {
-  const spyLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const _spyLog = vi.spyOn(console, "log").mockImplementation(() => {});
 
   test("clean", async () => {
     const option = initOptions({ distDir: "./cleanTest" });

--- a/__test__/Copy.spec.ts
+++ b/__test__/Copy.spec.ts
@@ -1,4 +1,4 @@
-import path from "path";
+import path from "node:path";
 import { afterAll, describe, expect, test } from "vitest";
 import { getCopyTaskSet, getDistDir, getSrcDir } from "../src/Copy.js";
 import { initOptions } from "../src/Option.js";
@@ -37,8 +37,8 @@ describe("Copy", () => {
     const copyTaskSet = getDefaultCopyTasks();
     await copyTaskSet.copy();
 
-    isExistFile(copyImgDir + "/btn045_01.png");
-    isExistFile(copyImgDir + "/sub/btn045_01.png");
+    isExistFile(`${copyImgDir}/btn045_01.png`);
+    isExistFile(`${copyImgDir}/sub/btn045_01.png`);
   });
 
   test("watchCopy", async () => {

--- a/__test__/Copy.watch.spec.ts
+++ b/__test__/Copy.watch.spec.ts
@@ -1,8 +1,8 @@
-import { test, expect, describe, afterAll } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import { afterAll, describe, expect, test } from "vitest";
 import { getCopyTaskSet } from "../src/Copy.js";
-import { InitializedOption } from "../src/Option.js";
-import fs from "fs";
-import path from "path";
+import type { InitializedOption } from "../src/Option.js";
 import { removeDir } from "./Util.js";
 
 const copyTestDir = "./test_for_copy";

--- a/__test__/EJS.spec.ts
+++ b/__test__/EJS.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, vi } from "vitest";
+import { afterAll, describe, expect, test, vi } from "vitest";
 import { getBundlerSet } from "../src/Bundler.js";
 import { getHTLMGenerator } from "../src/EJS.js";
 import { initOptions } from "../src/Option.js";
@@ -11,6 +11,10 @@ describe("EJS", () => {
   };
 
   const _spyLog = vi.spyOn(console, "log").mockImplementation(() => {});
+
+  afterAll(() => {
+    _spyLog.mockRestore();
+  });
 
   test("getHTLMGenerator", () => {
     const ejsTasks = generateDefaultTasks();

--- a/__test__/EJS.spec.ts
+++ b/__test__/EJS.spec.ts
@@ -1,8 +1,8 @@
+import { describe, expect, test, vi } from "vitest";
+import { getBundlerSet } from "../src/Bundler.js";
 import { getHTLMGenerator } from "../src/EJS.js";
 import { initOptions } from "../src/Option.js";
-import { getBundlerSet } from "../src/Bundler.js";
 import { isExistFile } from "./Util.js";
-import { describe, test, vi, expect } from "vitest";
 
 describe("EJS", () => {
   const generateDefaultTasks = () => {
@@ -10,7 +10,8 @@ describe("EJS", () => {
     return getHTLMGenerator(option);
   };
 
-  const spyLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const _spyLog = vi.spyOn(console, "log").mockImplementation(() => {});
+
   test("getHTLMGenerator", () => {
     const ejsTasks = generateDefaultTasks();
     expect(ejsTasks.generateHTML).toBeTruthy();

--- a/__test__/Option.spec.ts
+++ b/__test__/Option.spec.ts
@@ -1,5 +1,5 @@
+import { describe, expect, test } from "vitest";
 import { initOptions } from "../src/Option.js";
-import { describe, test, expect } from "vitest";
 
 describe("Option", () => {
   test("default option", () => {

--- a/__test__/Style.spec.ts
+++ b/__test__/Style.spec.ts
@@ -1,8 +1,8 @@
-import { initOptions } from "../src/Option.js";
+import { afterAll, describe, expect, test } from "vitest";
 import { getCopyTaskSet } from "../src/Copy.js";
+import { initOptions } from "../src/Option.js";
 import { getStyleTask } from "../src/Style.js";
 import { isExistFile, removeDir } from "./Util.js";
-import { describe, test, expect, afterAll } from "vitest";
 
 const testDir = "./test_for_style";
 
@@ -22,7 +22,7 @@ describe("Style", () => {
 
     const styleTask = getStyleTask();
     await styleTask();
-    isExistFile(testDir + "/styles.css");
-    isExistFile(testDir + "/GitHub-Mark-Light-64px.png");
+    isExistFile(`${testDir}/styles.css`);
+    isExistFile(`${testDir}/GitHub-Mark-Light-64px.png`);
   });
 });

--- a/__test__/Util.ts
+++ b/__test__/Util.ts
@@ -1,5 +1,5 @@
-import fs from "fs";
-import path from "path";
+import fs from "node:fs";
+import path from "node:path";
 import { expect } from "vitest";
 
 function isExist(relativePath: string): boolean {

--- a/__test__/cli/CLI.option.spec.ts
+++ b/__test__/cli/CLI.option.spec.ts
@@ -1,4 +1,4 @@
-import { vi, test, expect, type Mock, beforeEach, describe, it } from "vitest";
+import { beforeEach, describe, expect, it, type Mock, test, vi } from "vitest";
 import { runCommand } from "../../src/runCommand.js";
 
 // モック用のタスクオブジェクト
@@ -14,6 +14,7 @@ vi.mock("../../src/index.js", () => ({
 
 // // モック関数をインポート（必ず vi.mock の後）
 import { generateTasks } from "../../src/index.js";
+
 const mockGenerateTasks = generateTasks as Mock;
 
 beforeEach(() => {

--- a/__test__/cli/CLI.spec.ts
+++ b/__test__/cli/CLI.spec.ts
@@ -1,4 +1,4 @@
-import { vi, test, expect } from "vitest";
+import { expect, test, vi } from "vitest";
 
 // モック用のタスクオブジェクト
 const mockTask = {

--- a/__test__/generateTask.spec.ts
+++ b/__test__/generateTask.spec.ts
@@ -1,12 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { generateTasks } from "../src/index";
-
 // モック対象モジュールを名前付き import
 import * as BundlerModule from "../src/Bundler.js";
-import * as EJSModule from "../src/EJS.js";
-import * as CopyModule from "../src/Copy.js";
-import * as StyleModule from "../src/Style.js";
 import * as CleanModule from "../src/Clean.js";
+import * as CopyModule from "../src/Copy.js";
+import * as EJSModule from "../src/EJS.js";
+import { generateTasks } from "../src/index";
+import * as StyleModule from "../src/Style.js";
 
 describe("generateTasks", () => {
   let mockBundlerSet: {

--- a/__test__/generateTask.spec.ts
+++ b/__test__/generateTask.spec.ts
@@ -14,8 +14,8 @@ describe("generateTasks", () => {
   };
   let mockEJSTasks: EJSModule.EJSTasks;
   let mockCopyTasks: CopyModule.CopyTaskSet;
-  let mockStyleTask;
-  let mockCleanTask;
+  let mockStyleTask: () => Promise<void>;
+  let mockCleanTask: () => Promise<void>;
 
   beforeEach(() => {
     vi.restoreAllMocks();

--- a/__test__/indexScript.spec.js
+++ b/__test__/indexScript.spec.js
@@ -1,7 +1,7 @@
-import { describe, it, expect } from "vitest";
-import fs from "fs";
-import vm from "vm";
-import path from "path";
+import fs from "node:fs";
+import path from "node:path";
+import vm from "node:vm";
+import { describe, expect, it } from "vitest";
 
 // Read the script file content
 const scriptPath = path.resolve(__dirname, "../template/indexScript.js");

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.0.6/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true,
+    "defaultBranch": "main"
+  },
+  "files": {
+    "ignoreUnknown": false
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 80
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true
+    }
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "double"
+    }
+  },
+  "assist": {
+    "enabled": true,
+    "actions": {
+      "source": {
+        "organizeImports": "on"
+      }
+    }
+  }
+}

--- a/demoSrc/demo.js
+++ b/demoSrc/demo.js
@@ -1,2 +1,3 @@
 import moment from "moment";
+
 console.log("packed", moment().format("YYYY/MM/DD HH:mm:ss"));

--- a/demoSrc/demoTypeScript.ts
+++ b/demoSrc/demoTypeScript.ts
@@ -1,2 +1,3 @@
-import * as moment from 'moment';
-console.log( "packed ts", moment().format("YYYY/MM/DD HH:mm:ss") );
+import * as moment from "moment";
+
+console.log("packed ts", moment().format("YYYY/MM/DD HH:mm:ss"));

--- a/demoSrc/sub/demoSub.js
+++ b/demoSrc/sub/demoSub.js
@@ -1,2 +1,3 @@
 import moment from "moment";
+
 console.log("packed sub", moment().format("YYYY/MM/DD HH:mm:ss"));

--- a/demoSrc/unbuildable.ts
+++ b/demoSrc/unbuildable.ts
@@ -1,5 +1,5 @@
 /**
  * A Jest unit test file to reproduce situations where a TypeScript transpile fails.
  */
-
+// biome-ignore lint/correctness/noUnusedVariables: used for testing purposes
 const x = y;

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "gulptask-demo-page": "bin/CLI.js"
       },
       "devDependencies": {
+        "@biomejs/biome": "2.0.6",
         "@masatomakino/release-helper": "^0.2.0",
         "@types/ejs": "^3.1.2",
         "@types/node": "^24.0.0",
@@ -33,7 +34,6 @@
         "lint-staged": "^16.1.0",
         "moment": "^2.29.4",
         "package-json-type": "^1.0.3",
-        "prettier": "^3.0.0",
         "webpack-glsl-loader": "^1.0.1"
       }
     },
@@ -1453,6 +1453,169 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@biomejs/biome": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.0.6.tgz",
+      "integrity": "sha512-RRP+9cdh5qwe2t0gORwXaa27oTOiQRQvrFf49x2PA1tnpsyU7FIHX4ZOFMtBC4QNtyWsN7Dqkf5EDbg4X+9iqA==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "bin": {
+        "biome": "bin/biome"
+      },
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/biome"
+      },
+      "optionalDependencies": {
+        "@biomejs/cli-darwin-arm64": "2.0.6",
+        "@biomejs/cli-darwin-x64": "2.0.6",
+        "@biomejs/cli-linux-arm64": "2.0.6",
+        "@biomejs/cli-linux-arm64-musl": "2.0.6",
+        "@biomejs/cli-linux-x64": "2.0.6",
+        "@biomejs/cli-linux-x64-musl": "2.0.6",
+        "@biomejs/cli-win32-arm64": "2.0.6",
+        "@biomejs/cli-win32-x64": "2.0.6"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-arm64": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.0.6.tgz",
+      "integrity": "sha512-AzdiNNjNzsE6LfqWyBvcL29uWoIuZUkndu+wwlXW13EKcBHbbKjNQEZIJKYDc6IL+p7bmWGx3v9ZtcRyIoIz5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-x64": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.0.6.tgz",
+      "integrity": "sha512-wJjjP4E7bO4WJmiQaLnsdXMa516dbtC6542qeRkyJg0MqMXP0fvs4gdsHhZ7p9XWTAmGIjZHFKXdsjBvKGIJJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.0.6.tgz",
+      "integrity": "sha512-ZSVf6TYo5rNMUHIW1tww+rs/krol7U5A1Is/yzWyHVZguuB0lBnIodqyFuwCNqG9aJGyk7xIMS8HG0qGUPz0SA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64-musl": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.0.6.tgz",
+      "integrity": "sha512-CVPEMlin3bW49sBqLBg2x016Pws7eUXA27XYDFlEtponD0luYjg2zQaMJ2nOqlkKG9fqzzkamdYxHdMDc2gZFw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.0.6.tgz",
+      "integrity": "sha512-geM1MkHTV1Kh2Cs/Xzot9BOF3WBacihw6bkEmxkz4nSga8B9/hWy5BDiOG3gHDGIBa8WxT0nzsJs2f/hPqQIQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64-musl": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.0.6.tgz",
+      "integrity": "sha512-mKHE/e954hR/hSnAcJSjkf4xGqZc/53Kh39HVW1EgO5iFi0JutTN07TSjEMg616julRtfSNJi0KNyxvc30Y4rQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-arm64": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.0.6.tgz",
+      "integrity": "sha512-290V4oSFoKaprKE1zkYVsDfAdn0An5DowZ+GIABgjoq1ndhvNxkJcpxPsiYtT7slbVe3xmlT0ncdfOsN7KruzA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-x64": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.0.6.tgz",
+      "integrity": "sha512-bfM1Bce0d69Ao7pjTjUS+AWSZ02+5UHdiAP85Th8e9yV5xzw6JrHXbL5YWlcEKQ84FIZMdDc7ncuti1wd2sdbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -4586,21 +4749,6 @@
         "node": "^10 || ^12 || >=14"
       }
     },
-    "node_modules/prettier": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
-      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
-      "dev": true,
-      "bin": {
-        "prettier": "bin/prettier.cjs"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
-      }
-    },
     "node_modules/pretty-ms": {
       "version": "9.2.0",
       "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.2.0.tgz",
@@ -6960,6 +7108,78 @@
         "@babel/helper-validator-identifier": "^7.27.1"
       }
     },
+    "@biomejs/biome": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.0.6.tgz",
+      "integrity": "sha512-RRP+9cdh5qwe2t0gORwXaa27oTOiQRQvrFf49x2PA1tnpsyU7FIHX4ZOFMtBC4QNtyWsN7Dqkf5EDbg4X+9iqA==",
+      "dev": true,
+      "requires": {
+        "@biomejs/cli-darwin-arm64": "2.0.6",
+        "@biomejs/cli-darwin-x64": "2.0.6",
+        "@biomejs/cli-linux-arm64": "2.0.6",
+        "@biomejs/cli-linux-arm64-musl": "2.0.6",
+        "@biomejs/cli-linux-x64": "2.0.6",
+        "@biomejs/cli-linux-x64-musl": "2.0.6",
+        "@biomejs/cli-win32-arm64": "2.0.6",
+        "@biomejs/cli-win32-x64": "2.0.6"
+      }
+    },
+    "@biomejs/cli-darwin-arm64": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.0.6.tgz",
+      "integrity": "sha512-AzdiNNjNzsE6LfqWyBvcL29uWoIuZUkndu+wwlXW13EKcBHbbKjNQEZIJKYDc6IL+p7bmWGx3v9ZtcRyIoIz5A==",
+      "dev": true,
+      "optional": true
+    },
+    "@biomejs/cli-darwin-x64": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.0.6.tgz",
+      "integrity": "sha512-wJjjP4E7bO4WJmiQaLnsdXMa516dbtC6542qeRkyJg0MqMXP0fvs4gdsHhZ7p9XWTAmGIjZHFKXdsjBvKGIJJQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@biomejs/cli-linux-arm64": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.0.6.tgz",
+      "integrity": "sha512-ZSVf6TYo5rNMUHIW1tww+rs/krol7U5A1Is/yzWyHVZguuB0lBnIodqyFuwCNqG9aJGyk7xIMS8HG0qGUPz0SA==",
+      "dev": true,
+      "optional": true
+    },
+    "@biomejs/cli-linux-arm64-musl": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.0.6.tgz",
+      "integrity": "sha512-CVPEMlin3bW49sBqLBg2x016Pws7eUXA27XYDFlEtponD0luYjg2zQaMJ2nOqlkKG9fqzzkamdYxHdMDc2gZFw==",
+      "dev": true,
+      "optional": true
+    },
+    "@biomejs/cli-linux-x64": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.0.6.tgz",
+      "integrity": "sha512-geM1MkHTV1Kh2Cs/Xzot9BOF3WBacihw6bkEmxkz4nSga8B9/hWy5BDiOG3gHDGIBa8WxT0nzsJs2f/hPqQIQw==",
+      "dev": true,
+      "optional": true
+    },
+    "@biomejs/cli-linux-x64-musl": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.0.6.tgz",
+      "integrity": "sha512-mKHE/e954hR/hSnAcJSjkf4xGqZc/53Kh39HVW1EgO5iFi0JutTN07TSjEMg616julRtfSNJi0KNyxvc30Y4rQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@biomejs/cli-win32-arm64": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.0.6.tgz",
+      "integrity": "sha512-290V4oSFoKaprKE1zkYVsDfAdn0An5DowZ+GIABgjoq1ndhvNxkJcpxPsiYtT7slbVe3xmlT0ncdfOsN7KruzA==",
+      "dev": true,
+      "optional": true
+    },
+    "@biomejs/cli-win32-x64": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.0.6.tgz",
+      "integrity": "sha512-bfM1Bce0d69Ao7pjTjUS+AWSZ02+5UHdiAP85Th8e9yV5xzw6JrHXbL5YWlcEKQ84FIZMdDc7ncuti1wd2sdbw==",
+      "dev": true,
+      "optional": true
+    },
     "@esbuild/aix-ppc64": {
       "version": "0.25.5",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.5.tgz",
@@ -8964,12 +9184,6 @@
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       }
-    },
-    "prettier": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
-      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
-      "dev": true
     },
     "pretty-ms": {
       "version": "9.2.0",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "webpack": "^5.87.0"
   },
   "devDependencies": {
+    "@biomejs/biome": "2.0.6",
     "@masatomakino/release-helper": "^0.2.0",
     "@types/ejs": "^3.1.2",
     "@types/node": "^24.0.0",
@@ -42,7 +43,6 @@
     "lint-staged": "^16.1.0",
     "moment": "^2.29.4",
     "package-json-type": "^1.0.3",
-    "prettier": "^3.0.0",
     "webpack-glsl-loader": "^1.0.1"
   },
   "overrides": {
@@ -71,6 +71,6 @@
     "doc": "docs"
   },
   "lint-staged": {
-    "*.{js,ts,css,md}": "prettier --write"
+    "*.{js,ts,css,md}": "biome format --write --no-errors-on-unmatched"
   }
 }

--- a/src/Bundler.ts
+++ b/src/Bundler.ts
@@ -1,8 +1,13 @@
-import webpack from "webpack";
-import { Configuration, RuleSetRule, Watching, Stats } from "webpack";
-import { InitializedOption, Option } from "./Option.js";
-import path from "path";
-import { fileURLToPath } from "url";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import webpack, {
+  type Configuration,
+  type RuleSetRule,
+  type Stats,
+  type Watching,
+} from "webpack";
+import type { InitializedOption, Option } from "./Option.js";
+
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 interface BundlerSet {
@@ -36,7 +41,7 @@ export async function getBundlerSet(
   return {
     bundleDevelopment: generateBundleDevelopment(config),
     watchBundle: () => {
-      return webpack(watchOption).watch({}, (err, stats) => {
+      return webpack(watchOption).watch({}, (_err, stats) => {
         handleStats(stats);
       });
     },
@@ -48,7 +53,7 @@ const generateBundleDevelopment = (
 ): (() => Promise<void | Error>) => {
   return () => {
     return new Promise<void | Error>((resolve, reject) => {
-      webpack(config, (err, stats) => {
+      webpack(config, (_err, stats) => {
         handleStats(stats);
         if (stats?.hasErrors()) {
           reject(new Error("demo script build failed."));

--- a/src/Bundler.ts
+++ b/src/Bundler.ts
@@ -15,13 +15,19 @@ interface BundlerSet {
   watchBundle: () => Watching;
 }
 
+interface CompilerOptions {
+  target?: string;
+  module?: string;
+  moduleResolution?: string;
+}
+
 interface TsRuleOptions {
   configFile?: string;
-  compilerOptions?: {
-    target?: string;
-    module?: string;
-    moduleResolution?: string;
-  };
+  compilerOptions?: CompilerOptions;
+}
+
+interface TsRuleOptionsWithCompilerOptions extends TsRuleOptions {
+  compilerOptions: CompilerOptions;
 }
 
 export async function getBundlerSet(
@@ -100,27 +106,27 @@ const getTypeScriptRule = (config: Configuration): RuleSetRule => {
 const checkTsRule = (
   config: Configuration,
   param?: unknown,
-): TsRuleOptions | undefined => {
+): TsRuleOptionsWithCompilerOptions | undefined => {
   if (param == null) return;
   const tsRule = getTypeScriptRule(config);
   if (!tsRule) return;
 
   const option = tsRule.options as TsRuleOptions;
   option.compilerOptions ??= {};
-  return option;
+  return option as TsRuleOptionsWithCompilerOptions;
 };
 
 const overrideTsTarget = (config: Configuration, target?: string) => {
   const option = checkTsRule(config, target);
   if (option) {
-    option.compilerOptions!.target = target;
+    option.compilerOptions.target = target;
   }
 };
 
 const overrideTsModule = (config: Configuration, module?: string) => {
   const option = checkTsRule(config, module);
   if (option) {
-    option.compilerOptions!.module = module;
+    option.compilerOptions.module = module;
   }
 };
 
@@ -130,7 +136,7 @@ const overrideTsModuleResolution = (
 ) => {
   const option = checkTsRule(config, moduleResolution);
   if (option) {
-    option.compilerOptions!.moduleResolution = moduleResolution;
+    option.compilerOptions.moduleResolution = moduleResolution;
   }
 };
 

--- a/src/Bundler.ts
+++ b/src/Bundler.ts
@@ -11,7 +11,7 @@ import type { InitializedOption, Option } from "./Option.js";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 interface BundlerSet {
-  bundleDevelopment: () => Promise<void | Error>;
+  bundleDevelopment: () => Promise<void>;
   watchBundle: () => Watching;
 }
 
@@ -56,9 +56,9 @@ export async function getBundlerSet(
 
 const generateBundleDevelopment = (
   config: Configuration,
-): (() => Promise<void | Error>) => {
+): (() => Promise<void>) => {
   return () => {
-    return new Promise<void | Error>((resolve, reject) => {
+    return new Promise<void>((resolve, reject) => {
       webpack(config, (_err, stats) => {
         handleStats(stats);
         if (stats?.hasErrors()) {

--- a/src/Bundler.ts
+++ b/src/Bundler.ts
@@ -99,7 +99,7 @@ const getTypeScriptRule = (config: Configuration): RuleSetRule => {
 
 const checkTsRule = (
   config: Configuration,
-  param?: any,
+  param?: unknown,
 ): TsRuleOptions | undefined => {
   if (param == null) return;
   const tsRule = getTypeScriptRule(config);

--- a/src/CLI.ts
+++ b/src/CLI.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
 
 import { runCommand } from "./runCommand.js";
+
 runCommand();

--- a/src/Clean.ts
+++ b/src/Clean.ts
@@ -1,5 +1,5 @@
-import { promises as fsPromises } from "fs";
-import { InitializedOption } from "./Option.js";
+import { promises as fsPromises } from "node:fs";
+import type { InitializedOption } from "./Option.js";
 
 export function getCleanTask(option: InitializedOption) {
   return async () => {

--- a/src/Copy.ts
+++ b/src/Copy.ts
@@ -1,8 +1,8 @@
-import path from "path";
-import { InitializedOption } from "./Option.js";
+import fs from "node:fs";
+import fsPromises from "node:fs/promises";
+import path from "node:path";
 import chokidar from "chokidar";
-import fsPromises from "fs/promises";
-import fs from "fs";
+import type { InitializedOption } from "./Option.js";
 
 /**
  * Copy task for demo assets

--- a/src/Copy.ts
+++ b/src/Copy.ts
@@ -8,8 +8,8 @@ import type { InitializedOption } from "./Option.js";
  * Copy task for demo assets
  */
 export interface CopyTaskSet {
-  copy: Function;
-  watchCopy: Function;
+  copy: () => void;
+  watchCopy: () => void;
 }
 
 let copyOption: InitializedOption;

--- a/src/Copy.ts
+++ b/src/Copy.ts
@@ -42,10 +42,7 @@ const isTargetFileType = (filePath: string): boolean => {
 };
 
 async function copy() {
-  const filter = async (
-    source: string,
-    destination: string,
-  ): Promise<boolean> => {
+  const filter = async (source: string): Promise<boolean> => {
     const stat = await fsPromises.lstat(source);
     if (stat.isDirectory()) return true;
     return isTargetFileType(source);

--- a/src/EJS.ts
+++ b/src/EJS.ts
@@ -1,14 +1,13 @@
-"use strict";
+import fs from "node:fs";
+import fsPromises from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import chokidar from "chokidar";
 import ejs from "ejs";
-import fs from "fs";
-import fsPromises from "fs/promises";
 import * as glob from "glob";
-import { IPackageJson } from "package-json-type";
-import path from "path";
-import { InitializedOption, Option } from "./Option.js";
+import type { IPackageJson } from "package-json-type";
+import type { InitializedOption, Option } from "./Option.js";
 
-import { fileURLToPath } from "url";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 let generatorOption: InitializedOption;
@@ -41,14 +40,14 @@ export function getHTLMGenerator(option: InitializedOption): EJSTasks {
  * 出力されたJSファイルを監視し、対応するHTMLファイルを出力するgulpタスク
  **/
 function getGenerateHTML(option: Option) {
-  return async function () {
+  return async () => {
     const targets = glob
       .sync(`**/${option.prefix}*.js`, {
         cwd: distDir,
       })
       .sort();
 
-    for (let scriptPath of targets) {
+    for (const scriptPath of targets) {
       await exportEJS(scriptPath, distDir);
     }
     await exportIndex(targets);

--- a/src/EJS.ts
+++ b/src/EJS.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import fsPromises from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import chokidar from "chokidar";
+import * as chokidar from "chokidar";
 import ejs from "ejs";
 import * as glob from "glob";
 import type { IPackageJson } from "package-json-type";
@@ -13,8 +13,8 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 let generatorOption: InitializedOption;
 let distDir: string;
 export interface EJSTasks {
-  generateHTML: Function;
-  watchHTML: Function;
+  generateHTML: () => Promise<void>;
+  watchHTML: () => chokidar.FSWatcher;
 }
 
 /**

--- a/src/Option.ts
+++ b/src/Option.ts
@@ -1,5 +1,4 @@
-import { ModuleKind, ScriptTarget, ModuleResolutionKind } from "typescript";
-import { RuleSetRule } from "webpack";
+import type { RuleSetRule } from "webpack";
 
 export interface Option {
   prefix?: string;

--- a/src/Style.ts
+++ b/src/Style.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { getDistDir } from "./Copy.js";
 
-export function getStyleTask(): Function {
+export function getStyleTask(): () => Promise<void> {
   return async () => {
     await fs.cp(getTemplateDir(), getDistDir(), {
       recursive: true,

--- a/src/Style.ts
+++ b/src/Style.ts
@@ -1,13 +1,13 @@
-import fs from "fs/promises";
-import path from "path";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { getDistDir } from "./Copy.js";
-import { fileURLToPath } from "url";
 
 export function getStyleTask(): Function {
   return async () => {
     await fs.cp(getTemplateDir(), getDistDir(), {
       recursive: true,
-      filter: async (src, dest) => {
+      filter: async (src, _dest) => {
         const stat = await fs.lstat(src);
         if (stat.isDirectory()) return true;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { getBundlerSet } from "./Bundler.js";
 import { getCleanTask } from "./Clean.js";
 import { getCopyTaskSet } from "./Copy.js";
 import { getHTLMGenerator } from "./EJS.js";
-import { initOptions, Option } from "./Option.js";
+import { initOptions, type Option } from "./Option.js";
 import { getStyleTask } from "./Style.js";
 
 export interface Tasks {

--- a/src/runCommand.ts
+++ b/src/runCommand.ts
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 
-import { Command, OptionValues } from "commander";
+import path from "node:path";
+import { Command, type OptionValues } from "commander";
 import { generateTasks } from "./index.js";
-import path from "path";
 
 export async function runCommand() {
   const program = new Command();

--- a/template/indexScript.js
+++ b/template/indexScript.js
@@ -1,6 +1,7 @@
 /**
  * デモパスからデモ名を抽出し、URLエンコードされたデモ名を返します (例: "sub/demoSub.html" -> "sub%2FdemoSub")
  */
+// biome-ignore lint/correctness/noUnusedVariables: used for demo name extraction
 function getDemoNameFromPath(path) {
   if (!path) return null;
 

--- a/template/styles.css
+++ b/template/styles.css
@@ -8,7 +8,7 @@ iframe {
   width: 100%;
   height: 100%;
   border: none;
-  vertical-align:bottom;
+  vertical-align: bottom;
 }
 
 #layout,
@@ -117,7 +117,6 @@ small screens.
   display: block; /* show this only on small screens */
   top: 0;
   left: 0; /* "#menu width" */
-  background: #000;
   background: rgba(0, 0, 0, 0.7);
   font-size: 10px; /* change this value to increase/decrease button size */
   z-index: 10;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,4 @@
-import path from "path";
+import path from "node:path";
 import * as glob from "glob";
 
 const initEntries = (srcDir, prefix) => {


### PR DESCRIPTION
Integrate Biome for code formatting and linting, update package dependencies, and improve type safety across various components. Refactor imports to use the 'node:' prefix and enhance code consistency in tests and source files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Biome configuration for code formatting and linting.
  * Integrated Biome checks into pre-push hooks and CI workflow.

* **Refactor**
  * Improved type safety and clarified function signatures in various modules.
  * Updated interface definitions for better code clarity and maintainability.
  * Switched core module imports to explicit Node.js specifiers (e.g., "node:fs").

* **Style**
  * Reformatted code and updated import order across multiple files for consistency.
  * Applied double quotes and improved whitespace in demo files.
  * Made minor CSS formatting improvements.

* **Chores**
  * Replaced Prettier with Biome in development dependencies and lint-staged configuration.
  * Added Biome ignore directives for specific linting rules in demo and template files.

* **Tests**
  * Enhanced test cleanup by restoring mocked console methods after all tests.
  * Updated import styles and grouped imports for clarity in test files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->