### PR TITLE
📝 Add docstrings to `fix/favicon-404-error`

### DIFF
--- a/src/Style.ts
+++ b/src/Style.ts
@@ -3,6 +3,13 @@ import path from "path";
 import { getDistDir } from "./Copy.js";
 import { fileURLToPath } from "url";
 
+/**
+ * Returns an asynchronous task that copies style-related files and directories from the template directory to the distribution directory.
+ *
+ * Only directories and files with `.css`, `.png`, or `.ico` extensions are included in the copy operation.
+ * 
+ * @returns An asynchronous function that performs the filtered copy operation when invoked
+ */
 export function getStyleTask(): Function {
   return async () => {
     await fs.cp(getTemplateDir(), getDistDir(), {


### PR DESCRIPTION
Docstrings generation was requested by @MasatoMakino.

* https://github.com/MasatoMakino/gulptask-demo-page/pull/547#issuecomment-3011929609

The following files were modified:

* `src/Style.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added detailed documentation for the style copying functionality, clarifying which file types are included in the operation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->