### PR TITLE
chore: Remove Code Climate badges from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 
 [![MIT License](http://img.shields.io/badge/license-MIT-blue.svg?style=flat)](LICENSE)
 [![build test](https://github.com/MasatoMakino/gulptask-demo-page/actions/workflows/buildJS.yml/badge.svg)](https://github.com/MasatoMakino/gulptask-demo-page/actions/workflows/buildJS.yml)
-[![Maintainability](https://api.codeclimate.com/v1/badges/c85d13ff544137ebc8ac/maintainability)](https://codeclimate.com/github/MasatoMakino/gulptask-demo-page/maintainability)
-[![Test Coverage](https://api.codeclimate.com/v1/badges/c85d13ff544137ebc8ac/test_coverage)](https://codeclimate.com/github/MasatoMakino/gulptask-demo-page/test_coverage)
 
 [GitHub](https://github.com/MasatoMakino/gulptask-demo-page.git)
 


### PR DESCRIPTION
## Summary

- Remove Code Climate Maintainability badge
- Remove Code Climate Test Coverage badge

## Background

Code Climate service has been discontinued. This PR removes the remaining badge references from README.md.

## Cleanup History

All other Code Climate related configurations have already been removed:

- `.codeclimate.yml` - Removed in Nov 2022 (commit 0aa01b4)
- `.github/workflows/coverage.yml` - Removed in Sep 2025 (commit 623d47e)
- GitHub Secrets (`CC_TEST_REPORTER_ID`, `CC_REPORTER_TOKEN`) - Already removed

This PR completes the cleanup by removing the last remaining references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated README documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->