### PR TITLE
refactor: simplify DevContainer and switch to lightweight image

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,11 +1,6 @@
-FROM mcr.microsoft.com/devcontainers/javascript-node:22
+FROM node:22-bookworm-slim
 
-ARG WORKSPACE_NAME
-
-USER root
-
-# Pre-create volume mount point and set ownership to node user
-RUN mkdir -p /workspaces/${WORKSPACE_NAME}/node_modules && \
-    chown -R node:node /workspaces/${WORKSPACE_NAME}
-
-USER node
+# Install Git for Biome --staged option support
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    && rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,19 +2,12 @@
   "name": "gulptask-demo-page npm Runner (Node 22)",
   "build": {
     "dockerfile": "Dockerfile",
-    "context": "..",
-    "args": {
-      "WORKSPACE_NAME": "${localWorkspaceFolderBasename}"
-    }
+    "context": ".."
   },
   "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
   "workspaceMount": "source=${localWorkspaceFolder},target=/workspaces/${localWorkspaceFolderBasename},type=bind,consistency=cached",
   "remoteUser": "node",
   "runArgs": ["--cap-drop=ALL", "--name=gulptask-demo-page-npm-runner"],
-  "mounts": [
-    "source=${localWorkspaceFolderBasename}-npm-runner-node_modules,target=${containerWorkspaceFolder}/node_modules,type=volume",
-    "source=${localWorkspaceFolder}/.devcontainer,target=/workspaces/${localWorkspaceFolderBasename}/.devcontainer,type=bind,readonly"
-  ],
   "postCreateCommand": "npm ci",
   "postStartCommand": "npm audit --audit-level=moderate || true",
   "containerEnv": {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,34 @@ devcontainer up --workspace-folder .
 devcontainer stop --workspace-folder .
 ```
 
+### Architecture
+
+- Base image: `node:22-bookworm-slim` (with Git installed)
+- Security: `--cap-drop=ALL` (removes all Linux capabilities)
+- Non-root user: `node` (UID:1000, GID:1000)
+- Port forwarding: Not configured (no services exposed by default)
+
+### Security Benefits
+
+- Host OS npm is never executed (protection from malicious package scripts)
+- Container runs with minimal Linux capabilities (`--cap-drop=ALL`)
+- Non-root user (node) execution in container
+- Automatic `npm audit` on container start
+
+**Note on Security Trade-off:**
+Volume-based node_modules isolation was removed to restore host IDE access to TypeScript type definitions. Security now relies on container user and capability restrictions rather than volume isolation. This trade-off prioritizes developer experience (IDE type support) while maintaining npm execution isolation.
+
+### Image Size Optimization
+
+The project uses a custom lightweight Docker image instead of the full Microsoft DevContainer image:
+
+| Image | Size | Features |
+|-------|------|----------|
+| `mcr.microsoft.com/devcontainers/javascript-node:22` (previous) | ~1.12 GB | Full-featured (Git, GCC, Python, etc.) |
+| `node:22-bookworm-slim` + Git (current) | ~319 MB | Minimal + Git for Biome support |
+
+**Reduction**: 72% size decrease (1.12 GB → 319 MB)
+
 ## Development Commands
 
 **All commands must be run inside the DevContainer** using the `devcontainer exec` wrapper:


### PR DESCRIPTION
## Summary

Switch from Microsoft DevContainer image (1.12 GB) to custom lightweight image (319 MB) and remove Docker named volume for node_modules.

## Background

The previous configuration used:
1. Large Microsoft DevContainer image (~1.12 GB)
2. Docker named volume to completely isolate node_modules from host OS

While this provided strong isolation, it had two drawbacks:
- Large image size affecting download and build times
- Prevented host IDE from accessing TypeScript type definitions

After evaluation, we determined that:
- npm execution isolation (achieved through container) is the primary security concern
- Image size optimization improves development experience
- node_modules access from host IDE is essential for TypeScript development

## Changes

### Modified
- **.devcontainer/Dockerfile**
  - Switch base image from `mcr.microsoft.com/devcontainers/javascript-node:22` to `node:22-bookworm-slim`
  - Add Git installation (required for Biome `--staged` option)
  - Remove volume mount point creation code
  - Remove WORKSPACE_NAME build argument

- **.devcontainer/devcontainer.json**
  - Remove named volume mount configuration for node_modules
  - Remove readonly .devcontainer mount (was preventing file modifications)
  - Remove build.args configuration
  - Keep `remoteUser: "node"` for security

- **CLAUDE.md**
  - Add "Architecture" section with base image details
  - Add "Security Benefits" section explaining security trade-offs
  - Add "Image Size Optimization" section with comparison table

## Benefits
- 🎯 **72% image size reduction** (1.12 GB → 319 MB)
- ⚡ **Faster builds**: Smaller image means faster downloads and builds
- ✨ **Simpler configuration**: Less complex DevContainer setup
- 🔧 **Host IDE support**: TypeScript type definitions accessible from host
- 💡 **Better DX**: Restored IntelliSense and auto-completion
- 🔒 **Security maintained**: npm execution still isolated in container
- 🛠️ **Git support**: Biome `--staged` option now works in pre-commit hook

## Security Trade-off
- **Before**: Complete node_modules isolation (higher security, no IDE type support, large image)
- **After**: npm execution isolated, node_modules accessible to host IDE, smaller image (balanced approach)

## Image Size Comparison

| Image | Size | Features |
|-------|------|----------|
| `mcr.microsoft.com/devcontainers/javascript-node:22` | ~1.12 GB | Full-featured (Git, GCC, Python, etc.) |
| `node:22-bookworm-slim` + Git | ~319 MB | Minimal + Git (**current**) |

## Test plan
- [x] DevContainer builds successfully with new Dockerfile
- [x] DevContainer starts and npm ci runs
- [x] Git is available in container
- [x] node_modules accessible from host OS
- [x] IDE type support works on host
- [x] pre-commit hooks work with Biome --staged
- [x] All tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development container with a lightweight base image and simplified configuration.
  * Enhanced development environment documentation with architecture and security best practices.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->