### PR TITLE
ci: add Node.js v24 to CI test matrix

### DIFF
--- a/.github/workflows/buildJS.yml
+++ b/.github/workflows/buildJS.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        node-version: [20.x, 22.x]
+        node-version: [20.x, 22.x, 24.x]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,4 @@ test_for_style/
 
 .claude/settings.local.json
 .local-notes/
+.op/


### PR DESCRIPTION
## Summary
- Add Node.js v24 to CI test matrix alongside v20 and v22
- Add `.op/` to `.gitignore` (1Password CLI directory scope config)

## Scope

**Changes:**
- CI matrix: `[20.x, 22.x]` → `[20.x, 22.x, 24.x]`
- `.gitignore`: Add `.op/` directory

**Unchanged:**
- `npm_publish.yml` (uses fixed Node.js 20 for publishing)

## Test plan
- [ ] Verify CI runs successfully on all three Node.js versions (20.x, 22.x, 24.x)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Node.js 24.x to continuous integration testing
  * Updated version control configuration

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->