### PR TITLE
fix: use cheap-module-source-map for TypeScript source map chaining

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,26 @@ Corresponds to TypeScript's `tsconfig.compilerOptions.module`. See the official 
 
 Corresponds to TypeScript's `tsconfig.compilerOptions.moduleResolution`. See the official documentation for details. Example: node, node16, bundler
 
+### TypeScript Source Map Configuration
+
+To enable TypeScript source mapping in browser DevTools during watch mode, add the `--sourceMap` flag to your library project's tsc command:
+
+```bash
+tsc --sourceMap
+```
+
+Alternatively, configure your `tsconfig.json`:
+
+```json
+{
+  "compilerOptions": {
+    "sourceMap": true
+  }
+}
+```
+
+This generates `.js.map` files that allow browser DevTools to map bundled JavaScript back to original TypeScript source files.
+
 ### Complete Example
 
 This example demonstrates common CLI options:

--- a/src/Bundler.ts
+++ b/src/Bundler.ts
@@ -42,7 +42,7 @@ export async function getBundlerSet(
   checkEntries(config, option);
 
   const watchOption: Configuration = { ...config, mode: "development" };
-  overrideSourceMap(watchOption, "eval-cheap-source-map");
+  overrideSourceMap(watchOption, "cheap-module-source-map");
 
   return {
     bundleDevelopment: generateBundleDevelopment(config),


### PR DESCRIPTION
## Summary

- Change webpack devtool from `eval-cheap-source-map` to `cheap-module-source-map` to enable TypeScript source map chaining via ts-loader
- Add documentation for configuring `sourceMap` in library projects

## Scope

**Changes:**
- `src/Bundler.ts`: Update devtool setting for watch mode
- `README.md`: Add "TypeScript Source Map Configuration" section

**Unchanged:**
- Production build behavior (no source maps)
- API and CLI options

## Test plan

- [x] `npm run build` - Build succeeds
- [x] `npm test` - All 44 tests pass
- [x] `npm run testRun` - Demo page generation succeeds
- [ ] Manual verification: Open `docs/demo/index.html` in watch mode and confirm DevTools shows TypeScript sources

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on enabling and configuring TypeScript source maps in watch mode and via configuration files.

* **Improvements**
  * Updated development-time source map configuration for enhanced debugging experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->