### PR TITLE
refactor: replace moment with picocolors in demo files

### DIFF
--- a/demoSrc/demo.js
+++ b/demoSrc/demo.js
@@ -1,3 +1,3 @@
-import moment from "moment";
+import pc from "picocolors";
 
-console.log("packed", moment().format("YYYY/MM/DD HH:mm:ss"));
+console.log("packed", "Picocolors Supported", pc.isColorSupported);

--- a/demoSrc/demoTypeScript.ts
+++ b/demoSrc/demoTypeScript.ts
@@ -1,3 +1,3 @@
-import * as moment from "moment";
+import pc from "picocolors";
 
-console.log("packed ts", moment().format("YYYY/MM/DD HH:mm:ss"));
+console.log("packed ts", "Picocolors Supported", pc.isColorSupported);

--- a/demoSrc/sub/demoSub.js
+++ b/demoSrc/sub/demoSub.js
@@ -1,3 +1,3 @@
-import moment from "moment";
+import pc from "picocolors";
 
-console.log("packed sub", moment().format("YYYY/MM/DD HH:mm:ss"));
+console.log("packed sub", "Picocolors Supported", pc.isColorSupported);

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,6 @@
         "@types/ejs": "^3.1.2",
         "@types/node": "^25.0.3",
         "@vitest/coverage-istanbul": "^4.0.4",
-        "moment": "^2.29.4",
         "package-json-type": "^1.0.3",
         "webpack-glsl-loader": "^1.0.1"
       }
@@ -2646,16 +2645,6 @@
       "license": "ISC",
       "engines": {
         "node": ">=16 || 14 >=14.17"
-      }
-    },
-    "node_modules/moment": {
-      "version": "2.30.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
-      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/ms": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "@types/ejs": "^3.1.2",
     "@types/node": "^25.0.3",
     "@vitest/coverage-istanbul": "^4.0.4",
-    "moment": "^2.29.4",
     "package-json-type": "^1.0.3",
     "webpack-glsl-loader": "^1.0.1"
   },


### PR DESCRIPTION
## Summary

- Remove `moment` from devDependencies and replace with `picocolors`
- `picocolors` is already available as a transitive dependency via `ejs`
- Demo files now log `pc.isColorSupported` to verify external module imports work

## Scope

**Changes:**
- `demoSrc/demo.js`, `demoSrc/demoTypeScript.ts`, `demoSrc/sub/demoSub.js` - Use picocolors instead of moment
- `package.json` - Remove moment from devDependencies
- `package-lock.json` - Updated accordingly

**Unchanged:**
- CLI functionality
- Build process
- Test suite

## Test plan

- [x] `npm test` passes
- [x] Browser console shows "Picocolors Supported false" for each demo file

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed unused development dependency and updated demo output to display color support information instead of timestamps.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->